### PR TITLE
Fix: some urls in docs

### DIFF
--- a/docs/pluginsdetail.md
+++ b/docs/pluginsdetail.md
@@ -26,7 +26,7 @@
 | Name                                                                                      | Description                                            |
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | [rhysd/accelerated-jk](https://github.com/rhysd/accelerated-jk)                           | Up/down movement acceleration                          |
-| [psliwka/vim-smoothie](https://github.com/yonchu/psliwka/vim-smoothie)                    | Smooth Scroll                                          |
+| [psliwka/vim-smoothie](https://github.com/psliwka/vim-smoothie)                           | Smooth Scroll                                          |
 | [junegunn/vim-easyalign](https://github.com/junegunn/vim-easyalign)                       | Easy Align                                             |
 | [simnalamburt/vim-mundo](https://github.com/simnalamburt/vim-mundo)                       | Ultimate mundo history visualizer                      |
 | [tpope/vim-repeat](https://github.com/tpope/vim-repeat)                                   | Operate Repeat                                         |

--- a/docs/pluginsdetail.md
+++ b/docs/pluginsdetail.md
@@ -27,7 +27,6 @@
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | [rhysd/accelerated-jk](https://github.com/rhysd/accelerated-jk)                           | Up/down movement acceleration                          |
 | [psliwka/vim-smoothie](https://github.com/psliwka/vim-smoothie)                           | Smooth Scroll                                          |
-| [junegunn/vim-easyalign](https://github.com/junegunn/vim-easyalign)                       | Easy Align                                             |
 | [simnalamburt/vim-mundo](https://github.com/simnalamburt/vim-mundo)                       | Ultimate mundo history visualizer                      |
 | [tpope/vim-repeat](https://github.com/tpope/vim-repeat)                                   | Operate Repeat                                         |
 | [easymotion/vim-easymotion](https://github.com/easymotion/vim-easymotion)                 | Vim motions on speed                                   |


### PR DESCRIPTION
As you can see, the vim-smoothie's url in docs and wiki was 404, so I update it.
BTW, I do not have permission to update this wiki which has the same issue. 